### PR TITLE
Fix Configuration path separator for Windows

### DIFF
--- a/src/main/java/com/icthh/xm/ms/configuration/repository/impl/JGitRepository.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/repository/impl/JGitRepository.java
@@ -34,6 +34,7 @@ import com.icthh.xm.ms.configuration.service.ConcurrentConfigModificationExcepti
 import com.icthh.xm.ms.configuration.utils.Task;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.lib.Repository;
@@ -153,7 +154,7 @@ public class JGitRepository implements PersistenceConfigRepository {
         return runWithLock(lock, gitProperties.getMaxWaitTimeSecond(), () -> {
             String commit = pull();
             Collection<File> files = listFiles(rootDirectory, INSTANCE, INSTANCE);
-            return new ConfigurationList(commit, files.stream().filter(excludeGitFiels()).map(file -> fileToConfiguration(file, commit)).collect(toList()));
+            return new ConfigurationList(commit, files.stream().filter(excludeGitFiels()).map(file -> fileToConfiguration(file)).collect(toList()));
         });
     }
 
@@ -166,9 +167,9 @@ public class JGitRepository implements PersistenceConfigRepository {
     }
 
     @SneakyThrows
-    private Configuration fileToConfiguration(File file, String commit) {
-        String path = getRelativePath(file);
+    private Configuration fileToConfiguration(File file) {
         String content = readFileToString(file, UTF_8);
+        String path = StringUtils.replaceChars(getRelativePath(file), File.separator, "/");
         return new Configuration(path, content);
     }
 

--- a/src/main/java/com/icthh/xm/ms/configuration/service/ConfigurationService.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/service/ConfigurationService.java
@@ -1,13 +1,6 @@
 package com.icthh.xm.ms.configuration.service;
 
-import static com.icthh.xm.commons.tenant.TenantContextUtils.getRequiredTenantKeyValue;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-
 import com.icthh.xm.commons.config.client.api.AbstractConfigService;
-import com.icthh.xm.commons.config.client.api.ConfigService;
 import com.icthh.xm.commons.config.domain.Configuration;
 import com.icthh.xm.commons.tenant.TenantContextHolder;
 import com.icthh.xm.ms.configuration.repository.DistributedConfigRepository;
@@ -15,16 +8,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.io.File;
+import java.util.*;
+
+import static com.icthh.xm.commons.tenant.TenantContextUtils.getRequiredTenantKeyValue;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -93,6 +88,7 @@ public class ConfigurationService extends AbstractConfigService implements Initi
 
     @SneakyThrows
     private Configuration toConfiguration(MultipartFile file) {
-        return new Configuration(file.getOriginalFilename(), IOUtils.toString(file.getInputStream(), UTF_8));
+        String path = StringUtils.replaceChars(file.getOriginalFilename(), File.separator, "/");
+        return new Configuration(path, IOUtils.toString(file.getInputStream(), UTF_8));
     }
 }


### PR DESCRIPTION
Replace the file system specific separator with forward slash ('/') in Configuration path