### PR TITLE
Fix startup failure due invalid application-prod properties

### DIFF
--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -99,9 +99,6 @@ jhipster:
             host: localhost
             port: 5000
             queue-size: 512
-        spectator-metrics: # Reports Spectator Circuit Breaker metrics in the logs
-            enabled: false
-            # edit spring.metrics.export.delay-millis to set report frequency
 
 # ===================================================================
 # Application specific properties


### PR DESCRIPTION
Fix application-prod.yml: remove deprecated spectator properties that caused startup failure