### PR TITLE
Feature/uaa roles and permissions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=configuration
 profile=dev
-version=2.0.1
+version=2.0.2
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/ms/configuration/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/config/ApplicationProperties.java
@@ -51,7 +51,7 @@ public class ApplicationProperties {
     @Getter
     @Setter
     public static class UaaPermissions {
-        private boolean enabled;
+        private String url;
         private int retryDelay;
     }
 }

--- a/src/main/java/com/icthh/xm/ms/configuration/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/config/ApplicationProperties.java
@@ -21,6 +21,7 @@ public class ApplicationProperties {
 
     private GitProperties git;
     private final Retry retry = new Retry();
+    private final UaaPermissions uaaPermissions = new UaaPermissions();
 
     private List<String> tenantIgnoredPathList = Collections.emptyList();
     private boolean kafkaEnabled;
@@ -45,5 +46,12 @@ public class ApplicationProperties {
         private int maxAttempts;
         private long delay;
         private int multiplier;
+    }
+
+    @Getter
+    @Setter
+    public static class UaaPermissions {
+        private boolean enabled;
+        private int retryDelay;
     }
 }

--- a/src/main/java/com/icthh/xm/ms/configuration/service/PermissionConfigurationService.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/service/PermissionConfigurationService.java
@@ -1,0 +1,128 @@
+package com.icthh.xm.ms.configuration.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.annotations.VisibleForTesting;
+import com.icthh.xm.commons.config.domain.Configuration;
+import com.icthh.xm.ms.configuration.utils.ConfigPathUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.*;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+/**
+ * Service that configures roles and permissions based on UAA microservice values.
+ * After the application is started, polls UAA configuration endpoint to
+ * get the configuration and then updates in-memory values. This flow is tenant-specific
+ * and turns ons via {@link #UAA_PERMISSIONS_PROPERTY} property in {@code /tenant-config.yml}.
+ * This allows keeping the configuration outside of VCS.
+ *
+ * <p>NOTE: It's expected that roles.yml and permissions.yml are added to .gitignore for
+ * the configured tenants
+ */
+@Component
+@ConditionalOnProperty(prefix = "application", value = "uaa-permissions.enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+class PermissionConfigurationService {
+
+    public static final String UAA_PERMISSIONS_PROPERTY = "uaa-permissions";
+    public static final String TENANT_CONFIG_YML = "/tenant-config.yml";
+    private final RestTemplate loadBalancedRestTemplate;
+    private final ConfigurationService configService;
+    private final TenantService tenantService;
+
+    @Value("${jhipster.security.client-authorization.access-token-uri:http://uaa/oauth/token}")
+    private String tokenUrl = "http://uaa/oauth/token";
+    @Value("${jhipster.security.client-authorization.client-id:internal}")
+    private String clientId;
+    @Value("${jhipster.security.client-authorization.client-secret:internal}")
+    private String clientSecret;
+
+    @EventListener
+    @Retryable(maxAttempts = Integer.MAX_VALUE,
+        backoff = @Backoff(delayExpression = "${application.uaa-permissions.retry-delay}"))
+    public void started(ApplicationReadyEvent event) {
+        log.info("Attempting to get permission configuration from UAA");
+
+        updateConfigurationFromUaa();
+    }
+
+    @VisibleForTesting
+    void updateConfigurationFromUaa() {
+        tenantService.getTenants("uaa").stream()
+            .filter(t -> "ACTIVE".equals(t.getState()))
+            .map(t -> t.getName().toUpperCase())
+            .filter(this::isUaaPermissionsEnabled)
+            .forEach(this::updatePermissionConfiguration);
+    }
+
+    private void updatePermissionConfiguration(String tenantKey) {
+        String token = getAuthToken(tenantKey);
+
+        configService.updateConfigurationInMemory(Configuration.of()
+            .path(String.format("/config/tenants/%s/roles.yml", tenantKey))
+            .content(getConfig(token, String.format("http://uaa/roles/%s/configuration", tenantKey)))
+            .build());
+
+        configService.updateConfigurationInMemory(Configuration.of()
+            .path(String.format("/config/tenants/%s/permissions.yml", tenantKey))
+            .content(getConfig(token, String.format("http://uaa/permissions/%s/configuration", tenantKey)))
+            .build());
+    }
+
+    @SneakyThrows
+    private boolean isUaaPermissionsEnabled(String tenantKey) {
+        Collection<Configuration> values = configService.getConfigurationMap(null, Collections.singleton(
+            ConfigPathUtils.getTenantPathPrefix(tenantKey) + TENANT_CONFIG_YML)).values();
+
+        Configuration configuration;
+        if (CollectionUtils.isEmpty(values) || (configuration = values.iterator().next()) == null) {
+            return false;
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+        Map<String, Object> value = objectMapper.readValue(configuration.getContent(), Map.class);
+
+        return Optional.ofNullable((Boolean) value.get(UAA_PERMISSIONS_PROPERTY))
+            .orElse(false);
+    }
+
+    private String getConfig(String token, String url) {
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Authorization", token);
+
+        return loadBalancedRestTemplate.exchange(url,
+            HttpMethod.GET, new HttpEntity<>(headers), String.class).getBody();
+    }
+
+    private String getAuthToken(String tenantName) {
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("x-tenant", tenantName);
+        headers.add("Authorization", "Basic " + new String(Base64.encodeBase64(String.format("%s:%s", clientId, clientSecret).getBytes())));
+
+        Map<String, String> response = loadBalancedRestTemplate.exchange(tokenUrl + "?grant_type=client_credentials",
+            HttpMethod.POST, new HttpEntity<>(headers), Map.class).getBody();
+
+        return String.format("%s %s", response.get("token_type"), response.get(("access_token")));
+    }
+
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -143,4 +143,7 @@ application:
         max-attempts: 3
         delay: 10000 #in milliseconds
         multiplier: 2
+    uaa-permissions:
+        enabled: false # enables uaa-stored permissions and roles
+        retry-delay: 1000
 

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -144,6 +144,6 @@ application:
         delay: 10000 #in milliseconds
         multiplier: 2
     uaa-permissions:
-        enabled: false # enables uaa-stored permissions and roles
+        url: http://uaa
         retry-delay: 1000
 

--- a/src/test/java/com/icthh/xm/ms/configuration/service/PermissionConfigurationServiceTestUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/configuration/service/PermissionConfigurationServiceTestUnitTest.java
@@ -1,0 +1,80 @@
+package com.icthh.xm.ms.configuration.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.icthh.xm.commons.config.domain.Configuration;
+import com.icthh.xm.ms.configuration.domain.TenantState;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PermissionConfigurationServiceTestUnitTest {
+
+    @InjectMocks
+    PermissionConfigurationService permissionConfigurationService;
+
+    @Mock
+    private RestTemplate loadBalancedRestTemplate;
+    @Mock
+    private ConfigurationService configService;
+    @Mock
+    private TenantService tenantService;
+
+    @Test
+    public void testConfigurationUpdate() {
+        //given
+        when(tenantService.getTenants("uaa"))
+            .thenReturn(ImmutableSet.of(
+                new TenantState("test-inactive", "INACTIVE"),
+                new TenantState("test-active-expected", "ACTIVE"),
+                new TenantState("test-active-no-config", "ACTIVE"),
+                new TenantState("test-active-disabled", "ACTIVE")
+            ));
+
+        when(configService.getConfigurationMap(any(),
+            any()))
+            .thenReturn(ImmutableMap.of("path",
+                new Configuration("path", "uaa-permissions: true")))
+            .thenReturn(ImmutableMap.of("path",
+                new Configuration("path", "uaa-permissions: false")))
+            .thenReturn(Collections.singletonMap("path", null));
+
+        when(loadBalancedRestTemplate.exchange(
+            ArgumentMatchers.contains("http://uaa/oauth/token?grant_type=client_credentials"),
+            eq(HttpMethod.POST), any(HttpEntity.class), any(Class.class)
+        )).thenReturn(new ResponseEntity<>(ImmutableMap.of(
+            "token_type", "test-type",
+            "access_token", "test-token"
+        ), HttpStatus.OK));
+
+        when(loadBalancedRestTemplate.exchange(
+            ArgumentMatchers.contains("/roles/TEST-ACTIVE-EXPECTED/configuration"),
+            eq(HttpMethod.GET), any(HttpEntity.class), any(Class.class)
+        )).thenReturn(new ResponseEntity<>("test-roles-configuration", HttpStatus.OK));
+
+        when(loadBalancedRestTemplate.exchange(
+            ArgumentMatchers.contains("/permissions/TEST-ACTIVE-EXPECTED/configuration"),
+            eq(HttpMethod.GET), any(HttpEntity.class), any(Class.class)
+        )).thenReturn(new ResponseEntity<>("test-permissions-configuration", HttpStatus.OK));
+
+        //when
+        permissionConfigurationService.updateConfigurationFromUaa();
+
+        //then
+        verify(configService).updateConfigurationInMemory(new Configuration("/config/tenants/TEST-ACTIVE-EXPECTED/roles.yml", "test-roles-configuration"));
+        verify(configService).updateConfigurationInMemory(new Configuration("/config/tenants/TEST-ACTIVE-EXPECTED/permissions.yml", "test-permissions-configuration"));
+        verify(configService, times(3)).getConfigurationMap(any(), any());
+        verifyNoMoreInteractions(configService);
+    }
+}


### PR DESCRIPTION
**Why:**
Needs the ability to keep permission and role configuration outside of the codebase. Instead, role and permission configurations are kept in the _xm-uaa ms_ database.
The feature can be turned on by a tenant configuration. 

**How:**
A mechanism that allows getting role and permission configurations from _xm-uaa ms_ on startup is added. It turns on by a tenant configuration. 
