### PR TITLE
Override PermissionMsNameFilter with custom implementation, that will…

### DIFF
--- a/src/main/java/com/icthh/xm/ms/configuration/service/filter/AlwaysTruePermissionMsNameFilter.java
+++ b/src/main/java/com/icthh/xm/ms/configuration/service/filter/AlwaysTruePermissionMsNameFilter.java
@@ -1,0 +1,13 @@
+package com.icthh.xm.ms.configuration.service.filter;
+
+import com.icthh.xm.commons.permission.service.filter.PermissionMsNameFilter;
+import org.springframework.stereotype.Component;
+
+@Component("permissionMsNameFilter")
+public class AlwaysTruePermissionMsNameFilter implements PermissionMsNameFilter {
+
+    @Override
+    public boolean filterPermission(String permissionMsName) {
+        return true;
+    }
+}

--- a/src/test/java/com/icthh/xm/ms/configuration/service/PrivilegeServiceIntTest.java
+++ b/src/test/java/com/icthh/xm/ms/configuration/service/PrivilegeServiceIntTest.java
@@ -11,7 +11,6 @@ import com.icthh.xm.commons.config.domain.Configuration;
 import com.icthh.xm.commons.permission.config.PermissionProperties;
 import com.icthh.xm.commons.permission.domain.Privilege;
 import com.icthh.xm.commons.permission.service.PermissionMappingService;
-import com.icthh.xm.commons.permission.service.filter.EqualsOrNullPermissionMsNameFilter;
 import com.icthh.xm.commons.request.XmRequestContext;
 import com.icthh.xm.commons.request.XmRequestContextHolder;
 import com.icthh.xm.commons.tenant.TenantContext;
@@ -20,6 +19,7 @@ import com.icthh.xm.commons.tenant.internal.DefaultTenantContextHolder;
 import com.icthh.xm.ms.configuration.config.RequestContextKeys;
 import com.icthh.xm.ms.configuration.domain.RequestSourceType;
 import com.icthh.xm.ms.configuration.domain.TenantState;
+import com.icthh.xm.ms.configuration.service.filter.AlwaysTruePermissionMsNameFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -58,7 +58,7 @@ public class PrivilegeServiceIntTest {
     @Mock
     private XmRequestContextHolder requestContextHolder;
     @Spy
-    private EqualsOrNullPermissionMsNameFilter permissionMsNameFilter = new EqualsOrNullPermissionMsNameFilter();
+    private AlwaysTruePermissionMsNameFilter permissionMsNameFilter = new AlwaysTruePermissionMsNameFilter();
     @Spy
     private PermissionMappingService permissionMappingService = new PermissionMappingService(permissionMsNameFilter);
 


### PR DESCRIPTION
… always return true.

Reasoning: when any microservice notifies config-app about changes in privileges, PrivilegeService will invoke PermissionMappingService#ymlToPermissionList, where default EqualsOrNullPermissionMsNameFilter will filter out all permissions that do not belong to 'config' app. This will result in removal of all other apps permissions