### PR TITLE
Update xm-commons to 5.0.36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=configuration
 profile=dev
 
-version=4.0.9
+version=4.0.10
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ springdocOpenapiVersion=2.6.0
 system_rules_version=1.19.0
 webcompere_system_stub=2.1.8
 
-xm_commons_version=5.0.21
+xm_commons_version=5.0.36
 
 jgit_version=7.3.0.202506031305-r
 


### PR DESCRIPTION
Bumps `xm_commons_version` from **5.0.21** to **5.0.36**.

## Verification

`./gradlew clean test` on Eclipse Temurin 25.0.1, Gradle 9.2.1:

| | |
|---|---|
| Result | BUILD SUCCESSFUL |
| Tests | **232** |
| Failures | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)