### PR TITLE
Fix /v3/api-docs: move springdoc to the Spring Boot 4 line

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=configuration
 profile=dev
 
-version=4.0.10
+version=4.0.11
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ mapstructVersion=1.6.3
 archunitJunit5Version=1.3.0
 jacksonDatabindNullableVersion=0.2.2
 lombok_version=1.18.42
-springdocOpenapiVersion=2.6.0
+springdocOpenapiVersion=3.0.3
 system_rules_version=1.19.0
 webcompere_system_stub=2.1.8
 

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -175,7 +175,7 @@ tenant.reject-suspended: false
 application:
     adminApiRestrictionEnabled: false
     super-tenants-list: XM, MANAGER
-    tenant-ignored-path-list: /api/token_key, /api/private/config_map, /api/private/config, /api/private/config_map/pattern
+    tenant-ignored-path-list: /api/token_key, /api/private/config_map, /api/private/config, /api/private/config_map/pattern, /v3/api-docs
     kafka-enabled: true
     kafka-system-queue: system_queue
     kafka-in-memory-config-topic: in_memory_config_topic


### PR DESCRIPTION
Fix /v3/api-docs: move springdoc to the Spring Boot 4 line

springdoc 2.x calls `new ControllerAdviceBean(Object)`. That constructor was
removed in Spring Framework 7, so after the move to Spring Boot 4 every
GET /v3/api-docs answered HTTP 500:

    java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'
      at org.springdoc.core.service.GenericResponseService.getGenericMapResponse(GenericResponseService.java:708)
      at org.springdoc.webmvc.api.OpenApiWebMvcResource.openapiJson(OpenApiWebMvcResource.java:114)

The app starts clean and /v3/api-docs/swagger-config still answers 200, so
nothing in the logs points at it — it only fails when the document is built.
Per springdoc's compatibility matrix, springdoc 3.x is the line for Boot 4.x.

Also points `tenant-ignored-path-list` at /v3/api-docs.
