### PR TITLE
Update xm-commons to 5.0.39

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ springdocOpenapiVersion=3.0.3
 system_rules_version=1.19.0
 webcompere_system_stub=2.1.8
 
-xm_commons_version=5.0.36
+xm_commons_version=5.0.39
 
 jgit_version=7.3.0.202506031305-r
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=configuration
 profile=dev
 
-version=4.0.11
+version=4.0.12
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0


### PR DESCRIPTION
Bumps xm_commons_version from 5.0.36 to 5.0.39, the current release
per Maven Central metadata (published 2026-08-09).

Verified with `./gradlew clean test` on Eclipse Temurin 25 and
Gradle 9.2.1: BUILD SUCCESSFUL, 232 tests, no failures.